### PR TITLE
remove mdx_truly_sane_lists extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -672,3 +672,7 @@ nav:
                     - META-INF/UnixProfile.substvar: examples/bwce/qa/projects/com.behaimits.sample.http.requestor.application/violation4.md
                     - META-INF/WindowsProfile.substvar: examples/bwce/qa/projects/com.behaimits.sample.http.requestor.application/violation5.md
             - QA Rules Statistics: examples/bwce/qa/common/invalidQARule.md
+            
+           
+hooks:
+  - remove-extensions.py

--- a/remove-extensions.py
+++ b/remove-extensions.py
@@ -1,0 +1,4 @@
+def on_config(config):
+    if 'mdx_truly_sane_lists' in config['markdown_extensions']:
+        config['markdown_extensions'].remove('mdx_truly_sane_lists')
+    return config


### PR DESCRIPTION
Removing the extension that caused tables and code blocks to display improperly.